### PR TITLE
Dependencies version upgrade

### DIFF
--- a/packages/functional_enum/pubspec.yaml
+++ b/packages/functional_enum/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.3.0
-  build: ^2.1.0
+  analyzer: ^3.2.0
+  build: ^2.2.1
   build_config: ^1.0.0
-  functional_enum_annotation: ^1.2.1
-  source_gen: ^1.1.0
+  functional_enum_annotation: ^1.2.2
+  source_gen: ^1.2.1


### PR DESCRIPTION
Upgraded dependencies to fix the analyzer incompatibility issues. 

- analyzer: ^2.3.0 -> ^3.2.0
- build: ^2.1.0 ->  ^2.2.1
- build_config: ^1.0.0
- functional_enum_annotation: ^1.2.1 ->  ^1.2.2
- source_gen: ^1.1.0 ->  ^1.2.1