### PR TITLE
fix: `@functionalEnum can only be applied on enum types`

### DIFF
--- a/packages/functional_enum/lib/src/enum_generator.dart
+++ b/packages/functional_enum/lib/src/enum_generator.dart
@@ -1,7 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
 
 class EnumExtensionGenerator {
-  final InterfaceElement element;
+  final EnumElement element;
   final _generated = StringBuffer();
 
   EnumExtensionGenerator(this.element)
@@ -45,7 +45,7 @@ class EnumExtensionGenerator {
 }
 
 class MethodGenerator {
-  final InterfaceElement element;
+  final EnumElement element;
   final List<FieldElement> values;
   final _generated = StringBuffer();
   late MethodType _methodType;

--- a/packages/functional_enum/lib/src/enum_generator.dart
+++ b/packages/functional_enum/lib/src/enum_generator.dart
@@ -1,7 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
 
 class EnumExtensionGenerator {
-  final ClassElement element;
+  final InterfaceElement element;
   final _generated = StringBuffer();
 
   EnumExtensionGenerator(this.element)
@@ -22,7 +22,11 @@ class EnumExtensionGenerator {
     _generated.writeln(field);
   }
 
-  void _generateCheckers() => element.fields.skip(2).forEach(_generateChecker);
+  void _generateCheckers() {
+    element.fields
+        .where((element) => element.isEnumConstant)
+        .forEach(_generateChecker);
+  }
 
   void _generateExtensionBottom() => _generated.writeln('}');
 
@@ -41,13 +45,14 @@ class EnumExtensionGenerator {
 }
 
 class MethodGenerator {
-  final ClassElement element;
+  final InterfaceElement element;
   final List<FieldElement> values;
   final _generated = StringBuffer();
   late MethodType _methodType;
 
   MethodGenerator({required this.element})
-      : values = element.fields.skip(2).toList();
+      : values =
+            element.fields.where((element) => element.isEnumConstant).toList();
 
   String generate(MethodType type) {
     _initialize(type);

--- a/packages/functional_enum/lib/src/functional_enum_generator.dart
+++ b/packages/functional_enum/lib/src/functional_enum_generator.dart
@@ -13,7 +13,7 @@ class FunctionalEnumGenerator extends GeneratorForAnnotation<FunctionalEnum> {
   @override
   FutureOr<String> generateForAnnotatedElement(
       Element element, ConstantReader annotation, BuildStep buildStep) {
-    if (element.kind == ElementKind.ENUM && element is ClassElement) {
+    if (element.kind == ElementKind.ENUM && element is InterfaceElement) {
       return EnumExtensionGenerator(element).generate();
     } else {
       throw InvalidGenerationSourceError(

--- a/packages/functional_enum/lib/src/functional_enum_generator.dart
+++ b/packages/functional_enum/lib/src/functional_enum_generator.dart
@@ -13,7 +13,7 @@ class FunctionalEnumGenerator extends GeneratorForAnnotation<FunctionalEnum> {
   @override
   FutureOr<String> generateForAnnotatedElement(
       Element element, ConstantReader annotation, BuildStep buildStep) {
-    if (element.kind == ElementKind.ENUM && element is InterfaceElement) {
+    if (element.kind == ElementKind.ENUM && element is EnumElement) {
       return EnumExtensionGenerator(element).generate();
     } else {
       throw InvalidGenerationSourceError(


### PR DESCRIPTION
I've broadened the check to `InterfaceElement` to include both `ClassElement` and `EnumElement`, although I'm not sure the former is still used for enums at all.